### PR TITLE
Maven regulation

### DIFF
--- a/async-job-service/pom.xml
+++ b/async-job-service/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/examples-jsapi/pom.xml
+++ b/examples-jsapi/pom.xml
@@ -19,12 +19,11 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jsapi</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <artifactId>resteasy-jsapi</artifactId> 
         </dependency>
     </dependencies>
     <build>

--- a/jaxb-json/pom.xml
+++ b/jaxb-json/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            
             <!-- filter out unwanted jars -->
             <exclusions>
                 <exclusion>

--- a/jaxrs2-async-pubsub-example/pom.xml
+++ b/jaxrs2-async-pubsub-example/pom.xml
@@ -12,30 +12,29 @@
     <name>Async HTTP Servlet 3.0 Test</name>
     <description/>
     <dependencies>
-        <dependency>
+         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>${project.version}</version>
+            <artifactId>resteasy-jaxrs</artifactId>           
         </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>async-http-servlet-3.0</artifactId>
-            <version>${project.version}</version>
-        </dependency> 
-        <dependency>
+
+	<dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+
+	<dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>            
+        </dependency>
+	<dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+        </dependency>
+	  <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>async-http-servlet-3.0</artifactId>
+           
+        </dependency> 
     </dependencies>
     <build>
         <plugins>

--- a/jsapi-servlet-test/pom.xml
+++ b/jsapi-servlet-test/pom.xml
@@ -16,28 +16,28 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <artifactId>resteasy-jaxrs</artifactId>         
         </dependency>
+	<dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>           
+        </dependency>
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            
         </dependency>
+        
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <artifactId>resteasy-jsapi</artifactId>            
         </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jsapi</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
-        </dependency>
+
         <dependency>
             <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <artifactId>commons-httpclient</artifactId>          
         </dependency>
     </dependencies>
     <build>

--- a/oauth-servlet-test/pom.xml
+++ b/oauth-servlet-test/pom.xml
@@ -11,29 +11,34 @@
     <packaging>war</packaging>
     <name>OAuth Servlet Test</name>
     <dependencies>
-        <dependency>
+       <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <artifactId>resteasy-jaxrs</artifactId>           
         </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-oauth</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-        </dependency>
-        <dependency>
+
+	<dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-        <dependency>
+
+	<dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+        </dependency>
+
+	 <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+           
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-oauth</artifactId>
+            
+        </dependency>
+            
+       
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
             <artifactId>jboss-annotations-api_1.2_spec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         </plugins>
     </build>
 
+
     <modules>
         <module>jaxrs2-async-pubsub-example</module>
         <module>jaxb-json</module>
@@ -47,4 +48,75 @@
         <module>spring-hibernate-contacts</module>
         <!-- <module>jsapi-servlet-test</module> -->
     </modules>
+
+    
+    <dependencyManagement>
+	<dependencies>
+	    <dependency>
+              <groupId>org.jboss.resteasy</groupId>
+              <artifactId>resteasy-jaxrs</artifactId>
+              <version>${project.version}</version>
+       	    </dependency>
+
+	    <dependency>
+               <groupId>org.jboss.resteasy</groupId>
+               <artifactId>resteasy-jsapi</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+
+	    <dependency>
+              <groupId>junit</groupId>
+              <artifactId>junit</artifactId>
+            </dependency>
+
+	    <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            </dependency>
+
+	    <dependency>
+              <groupId>org.jboss.resteasy</groupId>
+              <artifactId>resteasy-jaxb-provider</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+
+	    <dependency>
+               <groupId>org.jboss.resteasy</groupId>
+               <artifactId>resteasy-client</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+
+	    <dependency>
+               <groupId>commons-httpclient</groupId>
+               <artifactId>commons-httpclient</artifactId>
+               <version>3.1</version>
+            </dependency>
+
+	    <dependency>f<artifactId>hsqldb</artifactId>
+              <groupId>org.jboss.resteasy</groupId>
+              <artifactId>async-http-servlet-3.0</artifactId>
+              <version>${project.version}</version>
+            </dependency> 
+
+	    <dependency>
+               <groupId>org.jboss.resteasy</groupId>
+               <artifactId>resteasy-jackson2-provider</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+
+	    <dependency>
+               <groupId>org.jboss.resteasy</groupId>
+               <artifactId>resteasy-oauth</artifactId>
+               <version>${project.version}</version>
+            </dependency>
+
+	    <dependency>
+            <groupId>hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>1.8.0.7</version>
+        </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/resteasy-springMVC/pom.xml
+++ b/resteasy-springMVC/pom.xml
@@ -20,30 +20,29 @@
             <artifactId>resteasy-spring</artifactId>
             <version>3.1.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
+	 <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <artifactId>resteasy-client</artifactId>            
         </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
+	<dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>3.0.6.RELEASE</version>
+        </dependency>
+	 <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>           
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-        <dependency>
+
+	<dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
         </dependency>
-        <dependency>
+	 <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>tjws</artifactId>
             <version>3.1.0-SNAPSHOT</version>

--- a/smime/pom.xml
+++ b/smime/pom.xml
@@ -16,21 +16,22 @@
     <url>http://maven.apache.org</url>
 
     <dependencies>
-        <dependency>
+       <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
-            <version>${project.version}</version>
+            
         </dependency>
-        <dependency>
+	<dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
+	 <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-crypto</artifactId>
             <version>${project.version}</version>

--- a/wadl-example/pom.xml
+++ b/wadl-example/pom.xml
@@ -16,20 +16,20 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>${project.version}</version>
+            <artifactId>resteasy-jaxrs</artifactId>          
         </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-wadl</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
+
+	<dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
+	<dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-wadl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+	 <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
         </dependency>


### PR DESCRIPTION
added the common dependencies of the module POMs in the dependency management of the parent POM to better support the consistency of version.