### PR TITLE
Add Description on README for first example

### DIFF
--- a/oreilly-jaxrs-2.0-workbook/ex03_1/README.md
+++ b/oreilly-jaxrs-2.0-workbook/ex03_1/README.md
@@ -14,3 +14,25 @@ Building the project:
 mvn clean install
 
 This will build a WAR and run it with embedded Jetty
+
+Run Using Embedded Jetty
+-------------------------
+mvn jetty:run
+
+# Test the aplication with CURL
+------------------------
+1. make XML file
+
+touch customer.xml
+
+vim customer.xml
+
+<customer id="100"><first-name>Bill</first-name><last-name>Burke</last-name><street>256 Clarendon Street</street><city>Boston</city><state>MA</state><zip>02115</zip><country>USA</country></customer>
+
+(XML on the customer.xml has to be a one-liner)
+
+2. test application
+  
+curl -vX POST -H "Content-Type: application/xml" -d "@customer.xml" localhost:8080/services/customers
+
+curl -X GET localhost:8080/services/customers/1


### PR DESCRIPTION
Hello @liweinan I add some description for oreilly-jaxrs-2.0-workbook/ex03_1/README.md. 

For newcomers this might help, there is no need to deploy the war, just use the embedded Jetty and curl the resource.