### PR TITLE
Bumps from 6.2.3.Final to 6.2.4.Final.

### DIFF
--- a/async-job-service/pom.xml
+++ b/async-job-service/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
         <version.org.jboss.arquillian>1.7.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.junit>5.9.3</version.org.junit>
         <version.org.wildfly>28.0.0.Final</version.org.wildfly>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>

--- a/bootable-jar/pom.xml
+++ b/bootable-jar/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.junit>5.9.3</version.org.junit>
         <version.org.wildfly>28.0.0.Final</version.org.wildfly>
 

--- a/bootstrap-cdi/pom.xml
+++ b/bootstrap-cdi/pom.xml
@@ -39,7 +39,7 @@
         <version.jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise.cdi-api>
         <version.jakarta.ws.rs.api>3.1.0</version.jakarta.ws.rs.api>
         <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.junit>5.9.3</version.org.junit>
 
         <!-- Plugin Versions -->

--- a/contacts/pom.xml
+++ b/contacts/pom.xml
@@ -55,7 +55,7 @@
     <properties>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
         <version.org.jboss.arquillian>1.7.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.junit>5.9.3</version.org.junit>
         <version.org.wildfly>28.0.0.Final</version.org.wildfly>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>

--- a/examples-jsapi/pom.xml
+++ b/examples-jsapi/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.junit>5.9.3</version.org.junit>
     </properties>
 
@@ -76,13 +76,6 @@
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- Can be removed when RESTEASY-3241 is resolved and integrated -->
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/json-binding/pom.xml
+++ b/json-binding/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
         <version.org.jboss.arquillian>1.7.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.junit>5.9.3</version.org.junit>
         <version.org.wildfly>28.0.0.Final</version.org.wildfly>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>

--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.junit>5.9.3</version.org.junit>
         <version.org.wildfly>28.0.0.Final</version.org.wildfly>
         <version.eclipse.microprofile.openapi>3.1</version.eclipse.microprofile.openapi>

--- a/servlet-example/pom.xml
+++ b/servlet-example/pom.xml
@@ -32,7 +32,7 @@
     </scm>
 
     <properties>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.eclipse.jetty>11.0.15</version.org.eclipse.jetty>
     </properties>
 

--- a/smime/pom.xml
+++ b/smime/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
         <version.org.jboss.arquillian>1.7.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.junit>5.9.3</version.org.junit>
         <version.org.wildfly>28.0.0.Final</version.org.wildfly>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>

--- a/tracing-example/pom.xml
+++ b/tracing-example/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
         <version.org.jboss.arquillian>1.7.0.Final</version.org.jboss.arquillian>
-        <version.org.jboss.resteasy>6.2.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>6.2.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.resteasy.extensions>2.0.1.Final</version.org.jboss.resteasy.extensions>
         <version.org.junit>5.9.3</version.org.junit>
         <version.org.wildfly.arquillian>5.0.0.Alpha6</version.org.wildfly.arquillian>


### PR DESCRIPTION
- [Release notes](https://github.com/resteasy/resteasy/releases)
- [Commits](resteasy/resteasy@6.2.3.Final...6.2.4.Final)

replaces #132 