### PR TITLE
Revert "Bump org.eclipse.microprofile.openapi:microprofile-openapi-api from 3.1.1 to 4.0.1"

### DIFF
--- a/microprofile-openapi/pom.xml
+++ b/microprofile-openapi/pom.xml
@@ -37,7 +37,7 @@
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
         <version.org.jboss.resteasy>6.2.10.Final</version.org.jboss.resteasy>
         <version.org.junit>5.11.0</version.org.junit>
-        <version.eclipse.microprofile.openapi>4.0.1</version.eclipse.microprofile.openapi>
+        <version.eclipse.microprofile.openapi>3.1.1</version.eclipse.microprofile.openapi>
         <version.wildfly-maven-plugin>5.0.1.Final</version.wildfly-maven-plugin>
         <!-- Test properties -->
         <jboss.home>${project.build.directory}${file.separator}wildfly</jboss.home>


### PR DESCRIPTION
Reverts resteasy/resteasy-examples#224

WildFly does not ship with OpenAPI 4.0 so we should not upgrade it here.